### PR TITLE
feat: add metadata to `getUploadedPhotos` query response

### DIFF
--- a/api/graphql/modules/shared.js
+++ b/api/graphql/modules/shared.js
@@ -1,0 +1,11 @@
+const { gql } = require('apollo-server');
+
+const typeDefs = gql`
+  type Metadata {
+    totalCount: Int!
+  }
+`;
+
+module.exports = {
+  typeDefs,
+};

--- a/api/graphql/modules/uploadPhoto.js
+++ b/api/graphql/modules/uploadPhoto.js
@@ -4,7 +4,7 @@ const uploadPhotoResolvers = require('../resolvers/uploadPhoto');
 
 const typeDefs = gql`
   extend type Query {
-    getUploadedPhotos(productIds: [String], limit: Int, page: Int): [UploadPhoto!]!
+    getUploadedPhotos(productIds: [String], limit: Int, page: Int): UploadedPhotos!
     getUpload(id: String): UploadPhoto!
     getUserUploads(userId: String, limit: Int, page: Int): [UploadPhoto]
     getBrandUploads(brandId: String, userId: String): BrandUpload
@@ -66,6 +66,11 @@ const typeDefs = gql`
     hidden: Boolean
     createdAt: String!
     approved: Boolean
+  }
+
+  type UploadedPhotos {
+    data: [UploadPhoto!]!
+    metadata: Metadata!
   }
 
   input UploadPhotoInput {

--- a/api/graphql/modules/uploadPhoto.js
+++ b/api/graphql/modules/uploadPhoto.js
@@ -130,8 +130,13 @@ const typeDefs = gql`
     errorCount: Int
   }
 
+  type UploadedPhotoResponse {
+    isApproved: Boolean
+    id: String
+  }
+
   extend type Mutation {
-    addUploadedPhoto(uploadPhoto: UploadPhotoInput!): String
+    addUploadedPhoto(uploadPhoto: UploadPhotoInput!): UploadedPhotoResponse
     updateUploadedPhoto(uploadPhoto: UploadPhotoInput!): String
     verifyUploadedPhoto(uploadPhoto: UploadPhotoInput!): String
     likeUploadedPhoto(id: ID, userId: ID): Boolean

--- a/api/graphql/modules/user.js
+++ b/api/graphql/modules/user.js
@@ -6,7 +6,7 @@ const typeDefs = gql`
   extend type Query {
     user(id: ID!): User
     userBy(data: String!): User
-    me: User
+    me: User!
     users: [User]
     getSpotlightMembers(brandId: ID): [UploadPhoto]
     getUserByFirebaseId(firebaseId: ID!): User

--- a/api/graphql/resolvers/authentication.js
+++ b/api/graphql/resolvers/authentication.js
@@ -130,6 +130,7 @@ const registerUser = async (_, args, context) => {
       role: isAdmin ? 'customer' : 'member',
       email: email,
       status: 'pending',
+      currentBalance: 0,
       username: username,
       createdAt: currentDate,
       updatedAt: currentDate,

--- a/api/graphql/resolvers/uploadPhoto.js
+++ b/api/graphql/resolvers/uploadPhoto.js
@@ -758,6 +758,29 @@ const addUploadedPhoto = async (parent, args, context) => {
         .db(dbName)
         .collection('offers_info')
         .findOne({ type: 'feedback_answer' });
+      const lookUploadInfo = await dbClient
+        .db(dbName)
+        .collection('offers_info')
+        .findOne({ type: 'look_post' });
+
+      const currentUserInfo = await dbClient
+        .db(dbName)
+        .collection('users')
+        .findOne({ _id: new ObjectId(args.uploadPhoto.userId) });
+
+      await dbClient
+        .db(dbName)
+        .collection('users')
+        .updateOne(
+          { _id: new ObjectId(args.uploadPhoto.userId) },
+          {
+            $set: {
+              currentBalance:
+                Number(currentUserInfo.currentBalance) + Number(lookUploadInfo.amount),
+            },
+          }
+        );
+
       await dbClient
         .db(dbName)
         .collection('feedback_offers')
@@ -783,7 +806,10 @@ const addUploadedPhoto = async (parent, args, context) => {
 
     await storeUploadCarePhoto(args.uploadPhoto.uuid);
 
-    return upload.insertedId.toString();
+    return {
+      isApproved: photo.approved,
+      id: upload.insertedId.toString(),
+    };
   } catch (e) {
     return e;
   }

--- a/api/graphql/resolvers/uploadPhoto.js
+++ b/api/graphql/resolvers/uploadPhoto.js
@@ -28,6 +28,7 @@ const getUploadedPhotos = async (root, args, context, info) => {
         $facet: {
           metadata: [{ $count: 'totalCount' }],
           data: [
+            { $sort: { createdAt: -1 } },
             {
               $lookup: {
                 from: 'users',

--- a/server.js
+++ b/server.js
@@ -68,6 +68,7 @@ const startServer = async () => {
       require('./api/graphql/modules/compensation'),
       require('./api/graphql/modules/notification'),
       require('./api/graphql/modules/analytics'),
+      require('./api/graphql/modules/shared'),
       require('./api/graphql/modules/authentication'),
     ],
   });


### PR DESCRIPTION
The `totalCount` is used to make it easier to know when to stop fetching during the infinite scroll on the feed.